### PR TITLE
Add tox (and travis) config for automated tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ target/
 .settings
 .project
 .pydevproject
+.mypy_cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+sudo: false
+language: python
+python:
+  - "2.7"
+  - "3.5"
+  - "3.6"
+  - "3.7"
+install:
+  - pip install tox-travis codecov
+script: 
+  - tox
+  - ls -l .coverage
+  - codecov

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include AUTHORS.txt

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Deep GP
-=====
+=======
 
 The Python Implementation of Deep Gaussian Processes
 
@@ -7,3 +7,16 @@ Currently implemented models are
 
 * Deep GPs
 * Variational Auto-encoded Deep GPs 
+
+Testing locally
+---------------
+
+To run the PyDeepGP test suite on your own machine:
+
+1. Install [tox][tox]
+2. Clone this repo
+3. `cd` into this repo
+4. Run `tox` to run the test suite and report test outcomes
+
+[tox]: https://tox.readthedocs.io/en/latest/
+

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,17 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import io
 import os
 from setuptools import setup
-import numpy
 
 # Version number
 version = '1.0'
 
 def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+    with open(fname) as f:
+        contents = f.read()
+    return contents
 
 setup(name = 'DGP',
       version = version,
@@ -27,16 +29,27 @@ setup(name = 'DGP',
       package_dir={'deepgp': 'deepgp'},
       py_modules = ['deepgp.__init__'],
       long_description=read('README.md'),
-      install_requires=['numpy>=1.7', 'scipy>=0.12','GPy>=1.0'],
-      include_dirs=[numpy.get_include()],
+      install_requires=[
+          'numpy>=1.7',
+          'scipy>=0.12',
+          'GPy>=1.0',
+      ],
+      extras_require={
+          'test': [
+              'matplotlib',
+              'h5py',
+              'tables',
+              'theano',
+          ],
+      },
       classifiers=['License :: OSI Approved :: BSD License',
                    'Natural Language :: English',
                    'Operating System :: MacOS :: MacOS X',
                    'Operating System :: Microsoft :: Windows',
                    'Operating System :: POSIX :: Linux',
                    'Programming Language :: Python :: 2.7',
-                   'Programming Language :: Python :: 3.3',
-                   'Programming Language :: Python :: 3.4',
-                   'Programming Language :: Python :: 3.5'
+                   'Programming Language :: Python :: 3.5',
+                   'Programming Language :: Python :: 3.6',
+                   'Programming Language :: Python :: 3.7'
                    ]
       )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,25 @@
+[tox]
+envlist = py27, py35, py36, py37
+[testenv]
+extras = 
+    test
+passenv = DISPLAY BROWSER TOXENV CI TRAVIS TRAVIS_*
+install_command = pip install {opts} {packages}
+deps = codecov>=1.4.0
+#whitelist_externals = 
+commands = 
+    python -m unittest deepgp.testing.model_tests_basic
+
+; Used by pytest-cov
+[run]
+branch = True
+source = deepgp
+
+; Used by pytest-cov
+[report]
+exclude_lines =
+    if self.debug:
+    pragma: no cover
+    raise NotImplementedError
+    if __name__ == .__main__.:
+ignore_errors = True


### PR DESCRIPTION
See README for how tox can be used for local testing.

Also:
 - I've added a config file, `.travis.yml`, to allow for automated testing every time Pull Requests or Pushes are made against/to this GitHub repository.
   You'll need to enable this by following [this tutorial](https://docs.travis-ci.com/user/tutorial/) on the basics of testing using [travis-ci.org](travis-ci.org)
 - I've removed the build-time dependency on `numpy.get_packages()` as it didn't seem to be needed

NB joint effort with @fredblain for #hacktoberfest2019!